### PR TITLE
Set up automatic versioning from Git tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags for versioning
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 __pycache__
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Auto-generated version file
+src/babamul/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "babamul"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Python client for consuming ZTF/LSST alerts from BABAMUL Kafka streams"
 readme = "README.md"
 license = "MIT"
@@ -48,6 +48,12 @@ Repository = "https://github.com/boom-astro/babamul"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/babamul"]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/babamul/_version.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/babamul/__init__.py
+++ b/src/babamul/__init__.py
@@ -17,7 +17,10 @@ from .models import (
     ZtfPhotometry,
 )
 
-__version__ = "0.1.0"
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     # Main classes

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,6 @@ wheels = [
 
 [[package]]
 name = "babamul"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
This way, when we create a release on GitHub, the version will update automatically without needing to change any files in the repo. We can release with the tag `v0.1.0`, and it will be published to PyPI as `0.1.0`.