### PR TITLE
Improve kafka credentials validation

### DIFF
--- a/src/babamul/config.py
+++ b/src/babamul/config.py
@@ -89,11 +89,11 @@ class BabamulConfig:
             )
         if "@" in final_username:
             raise ValueError(
-                "Do not use your babamul account email as the username. Please provide the Kafka credentials created on the Babamul website."
+                "Do not use your babamul account email as the username. Please provide the Kafka credentials created on the Babamul website profile page."
             )
         if not final_username.startswith("babamul-"):
             raise ValueError(
-                "Invalid username format. Kafka username should start with 'babamul-'. Please provide the Kafka credentials created on the Babamul website."
+                "Invalid username format. Kafka username should start with 'babamul-'. Please provide the Kafka credentials created on the Babamul website profile page."
             )
 
         if not final_password:
@@ -102,7 +102,7 @@ class BabamulConfig:
             )
         if final_password.startswith("bbml_"):
             raise ValueError(
-                "Do not use your babamul API token as the password. Please provide the Kafka credentials created on the Babamul website."
+                "Do not use your babamul API token as the password. Please provide the Kafka credentials created on the Babamul website profile page."
             )
 
         return cls(

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -32,7 +32,7 @@ class TestAlertConsumerInit:
         monkeypatch.delenv("BABAMUL_KAFKA_PASSWORD", raising=False)
         with pytest.raises(ValueError,
                 match="Do not use your babamul account email as the username. "
-                      "Please provide the Kafka credentials created on the Babamul website."
+                      "Please provide the Kafka credentials created on the Babamul website profile page."
         ):
             AlertConsumer(username="babamul@email.com", password="pass", topics=["test.topic"])
 
@@ -42,7 +42,7 @@ class TestAlertConsumerInit:
         monkeypatch.delenv("BABAMUL_KAFKA_PASSWORD", raising=False)
         with pytest.raises(ValueError,
                 match="Invalid username format. Kafka username should start with 'babamul-'. "
-                      "Please provide the Kafka credentials created on the Babamul website."
+                      "Please provide the Kafka credentials created on the Babamul website profile page."
         ):
             AlertConsumer(username="username", password="pass", topics=["test.topic"])
 
@@ -59,7 +59,7 @@ class TestAlertConsumerInit:
         monkeypatch.delenv("BABAMUL_KAFKA_PASSWORD", raising=False)
         with pytest.raises(ValueError,
                 match="Do not use your babamul API token as the password. "
-                      "Please provide the Kafka credentials created on the Babamul website."
+                      "Please provide the Kafka credentials created on the Babamul website profile page."
         ):
             AlertConsumer(username="babamul-user", password="bbml_12345", topics=["test.topic"])
 


### PR DESCRIPTION
- Added checks to ensure kafka username is not an email (most of the time Babamul account email) and starts with 'babamul-'.
- Implemented validation to prevent using Babamul API token as the password.
- Updated tests to cover new validation scenarios for username and password.
- Fix consumer tests to clear old loaded Kafka env vars.